### PR TITLE
Explicitly exit the process on success

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "build": "rimraf dist && rollup -c && chmod +x dist/lib/cli.js && cp package.json dist/",
-    "dev": "ts-node-dev src/cli.ts",
+    "dev": "ts-node src/cli.ts",
+    "dev:watch": "ts-node-dev src/cli.ts",
     "release": "yarn build && cd dist && yarn publish --non-interactive"
   },
   "dependencies": {

--- a/src/commands/shoot.ts
+++ b/src/commands/shoot.ts
@@ -22,8 +22,9 @@ export async function shootCommand(options: {
     screenshotPaths = await config.shooter.shoot(`http://localhost:${port}`);
   } catch (e) {
     return fail(e.message);
+  } finally {
+    await stopRenderer();
   }
-  await stopRenderer();
   if (options.push) {
     const git = simpleGit();
     await git.addConfig("user.name", "🤖 Viteshot");
@@ -46,5 +47,6 @@ export async function shootCommand(options: {
       info("✅ Screenshots have not changed.");
     }
   }
-  return info("All done.");
+  info("All done.");
+  return process.exit(0);
 }


### PR DESCRIPTION
This fixes an issue where the Vite dev server didn't stop properly.

Fixes #47.