### PR TITLE
feat: adding configuration to allow for skipping individual component screenshots

### DIFF
--- a/docs/docs/how-it-works.md
+++ b/docs/docs/how-it-works.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # How ViteShot Works

--- a/docs/docs/managing-screenshots.md
+++ b/docs/docs/managing-screenshots.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Managing Screenshots

--- a/docs/docs/skipping-screenshots.mdx
+++ b/docs/docs/skipping-screenshots.mdx
@@ -1,0 +1,94 @@
+---
+sidebar_position: 5
+---
+
+# Skipping Screenshots
+
+ViteShot lets you specify a `skipScreenshot` boolean, allowing you skip taking a screenshot of a specific component.
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+  defaultValue="react"
+  values={[
+    { label: "React", value: "react" },
+    { label: "Preact", value: "preact" },
+    { label: "Solid", value: "solid" },
+    { label: "Svelte", value: "svelte" },
+    { label: "Vue 3", value: "vue" },
+  ]}
+>
+  <TabItem value="react">
+
+```jsx title="/src/components/example.screenshot.jsx"
+import React from "react";
+
+export const HelloWorld = () => {
+  return (
+    <div>Hello World</div>
+  );
+};
+HelloWorld.skipScreenshot = true;
+```
+
+  </TabItem>
+  <TabItem value="preact">
+
+```jsx title="/src/components/example.screenshot.jsx"
+import { h } from "preact";
+import { useState } from "preact/hooks";
+
+export const HelloWorld = () => {
+  return (
+    <div>Hello World</div>
+  );
+};
+HelloWorld.skipScreenshot = true;
+```
+
+  </TabItem>
+  <TabItem value="solid">
+
+```jsx title="/src/components/example.screenshot.jsx"
+import { createSignal } from "solid-js";
+
+export const HelloWorld = () => {
+  return (
+    <div>Hello World</div>
+  );
+};
+HelloWorld.skipScreenshot = true;
+```
+
+  </TabItem>
+  <TabItem value="svelte">
+
+```svelte title="/src/components/example.screenshot.svelte"
+<script lang="ts">
+  export skipScreenshot = true;
+</script>
+
+<div>Hello World</div>
+```
+
+  </TabItem>
+  <TabItem value="vue">
+
+```vue title="/src/components/example.screenshot.vue"
+<template>
+  <div>Hello World</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "HelloWorld",
+  skipScreenshot: true,
+});
+</script>
+```
+
+  </TabItem>
+</Tabs>

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Troubleshooting

--- a/renderers/preact.ts
+++ b/renderers/preact.ts
@@ -6,6 +6,7 @@ export async function renderScreenshots(
       string,
       Preact.ComponentType<{}> & {
         beforeScreenshot?: (element: HTMLElement) => Promise<void>;
+        skipScreenshot?: boolean;
       }
     ]
   >,
@@ -16,6 +17,10 @@ export async function renderScreenshots(
   for (const [name, Component] of components) {
     if (typeof Component !== "function") {
       // This is not a component.
+      continue;
+    }
+    if ((Component as any).skipScreenshot) {
+      // skipping this component
       continue;
     }
     root.innerHTML = "";

--- a/renderers/react.ts
+++ b/renderers/react.ts
@@ -7,6 +7,7 @@ export async function renderScreenshots(
       string,
       React.ComponentType<{}> & {
         beforeScreenshot?: (element: HTMLElement) => Promise<void>;
+        skipScreenshot?: boolean;
       }
     ]
   >,
@@ -17,6 +18,10 @@ export async function renderScreenshots(
   for (const [name, Component] of components) {
     if (typeof Component !== "function") {
       // This is not a component.
+      continue;
+    }
+    if ((Component as any).skipScreenshot) {
+      // skipping this component
       continue;
     }
     root.innerHTML = "";

--- a/renderers/solid.ts
+++ b/renderers/solid.ts
@@ -7,6 +7,7 @@ export async function renderScreenshots(
       string,
       ((props: {}) => JSX.Element) & {
         beforeScreenshot?: (element: HTMLElement) => Promise<void>;
+        skipScreenshot?: boolean;
       }
     ]
   >,
@@ -17,6 +18,10 @@ export async function renderScreenshots(
   for (const [name, Component] of components) {
     if (typeof Component !== "function") {
       // This is not a component.
+      continue;
+    }
+    if ((Component as any).skipScreenshot) {
+      // skipping this component
       continue;
     }
     root.innerHTML = "";

--- a/renderers/svelte.ts
+++ b/renderers/svelte.ts
@@ -10,6 +10,7 @@ export async function renderScreenshots(
           props: any;
         }): SvelteComponent & {
           beforeScreenshot?: (element: HTMLElement) => Promise<void>;
+          skipScreenshot?: boolean;
         };
       }
     ]
@@ -20,6 +21,10 @@ export async function renderScreenshots(
   for (const [name, Component] of components) {
     if (typeof Component !== "function") {
       // This is not a component.
+      continue;
+    }
+    if ((Component as any).skipScreenshot) {
+      // skipping this component
       continue;
     }
     root.innerHTML = "";

--- a/renderers/vue.ts
+++ b/renderers/vue.ts
@@ -4,13 +4,17 @@ export async function renderScreenshots(
   components: Array<
     [
       string,
-      Component & { beforeScreenshot?: (element: HTMLElement) => Promise<void> }
+      Component & { beforeScreenshot?: (element: HTMLElement) => Promise<void>, skipScreenshot?: boolean }
     ]
   >
 ) {
   // TODO: Support Wrapper in Vue.
   const root = document.getElementById("root")!;
   for (const [name, component] of components) {
+    if (component.skipScreenshot) {
+      // skipping this component
+      continue;
+    }
     root.innerHTML = "";
     let app: App | null = null;
     try {


### PR DESCRIPTION
Fixes #81 

Adding a way to skip individual component screenshots. The motivation is that we have some files with many components, but want to ignore a few.